### PR TITLE
bot: Change deploy method

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,20 +1,35 @@
-name: Manually Deploy to Heroku
+name: Heroku Container
 
 on: workflow_dispatch
 
+env:
+  IMAGE_NAME: slam-mirrorbot
+  HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+  HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
+  CONFIG_FILE_URL: ${{ secrets.CONFIG_FILE_URL }}
+
 jobs:
-  deploy:
+  build_and_push:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
-      - uses: akhileshns/heroku-deploy@v3.12.12
-        with:
-          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
-          heroku_app_name: ${{secrets.HEROKU_APP_NAME}}
-          heroku_email: ${{secrets.HEROKU_EMAIL}}
-          usedocker: true
-          docker_heroku_process_type: web
-          stack: "container"
-          region: "eu"
-        env:
-          HD_CONFIG_FILE_URL: ${{secrets.CONFIG_FILE_URL}}
+      
+      - name: Create heroku app and set region
+        run: heroku create -a "${HEROKU_APP_NAME}" --region eu
+
+      - name: Build the image
+        run: docker build . --file Dockerfile --tag "${IMAGE_NAME}"
+
+      - name: Login into Heroku Container registry
+        run: heroku container:login
+
+      - name: Push the image to Heroku
+        run: heroku container:push "${IMAGE_NAME}" -a "${HEROKU_APP_NAME}"
+        
+      - name: Release image to Heroku
+        run: heroku container:release "${IMAGE_NAME}" -a "${HEROKU_APP_NAME}"
+
+      - name: Set ENV
+        run: |
+            heroku config:set -a "${HEROKU_APP_NAME}" CONFIG_FILE_URL="${CONFIG_FILE_URL}"

--- a/README.md
+++ b/README.md
@@ -362,5 +362,6 @@ Thanks to:
 - [`zevtyardt`](https://github.com/zevtyardt) for some direct links
 - [`yash-dk`](https://github.com/yash-dk) for implementation of qBittorrent on Python
 - [`xyou365`](https://github.com/xyou365) for Service Accounts script
+- [`Adek` ](https://github.com/adekmaulana) heroku container idea build with github workflows
 
 And many more people who aren't mentioned here, but can be found in [Contributors](https://github.com/SlamDevs/slam-mirrorbot/graphs/contributors).


### PR DESCRIPTION
- change deploy method to heroku container registry
- for now, we no need HEROKU_EMAIL in github secrets
- update credits

Signed-off-by: GudMeong <avada758@gmail.com>